### PR TITLE
ci: add Linux amd64 release workflow

### DIFF
--- a/.github/workflows/release-linux-amd64.yml
+++ b/.github/workflows/release-linux-amd64.yml
@@ -1,0 +1,137 @@
+name: Build Linux AMD64 Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub release tag
+        required: true
+        default: v1.0.0
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-linux-amd64-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ShareGenerationClient
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    env:
+      TAG: ${{ inputs.tag }}
+      GOOS: linux
+      GOARCH: amd64
+      CGO_ENABLED: "1"
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes build-essential
+
+      - name: Verify checked-out tag
+        run: |
+          set -euo pipefail
+
+          ACTUAL_TAG="$(git describe --tags --exact-match)"
+
+          if [[ "${ACTUAL_TAG}" != "${TAG}" ]]; then
+            echo "Expected tag ${TAG}, checked out ${ACTUAL_TAG}"
+            exit 1
+          fi
+
+          echo "Building tag ${ACTUAL_TAG}"
+          git rev-parse HEAD
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build ShareGenerationClient
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          go build \
+            -mod=readonly \
+            -trimpath \
+            -ldflags="-s -w" \
+            -o build/ShareGenerationClient \
+            .
+
+      - name: Verify binary
+        run: |
+          set -euo pipefail
+
+          test -x build/ShareGenerationClient
+          file build/ShareGenerationClient
+          build/ShareGenerationClient --help
+
+      - name: Package release asset
+        id: package
+        run: |
+          set -euo pipefail
+
+          ARCHIVE="ShareGenerationClient-${TAG}-linux-amd64.tar.gz"
+          CHECKSUM="${ARCHIVE}.sha256"
+
+          mkdir -p dist/package
+          install -m 0755 \
+            build/ShareGenerationClient \
+            dist/package/ShareGenerationClient
+
+          tar \
+            --directory dist/package \
+            --sort=name \
+            --mtime='UTC 1970-01-01' \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            --create \
+            --file - \
+            ShareGenerationClient \
+            | gzip -n > "dist/${ARCHIVE}"
+
+          (
+            cd dist
+            sha256sum "${ARCHIVE}" > "${CHECKSUM}"
+          )
+
+          cat "dist/${CHECKSUM}"
+
+          echo "archive=${ARCHIVE}" >> "${GITHUB_OUTPUT}"
+          echo "checksum=${CHECKSUM}" >> "${GITHUB_OUTPUT}"
+
+      - name: Confirm release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}"
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh release upload "${TAG}" \
+            "dist/${{ steps.package.outputs.archive }}" \
+            "dist/${{ steps.package.outputs.checksum }}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber


### PR DESCRIPTION
Adds a manually triggered GitHub Actions workflow that:

- checks out an existing release tag
- builds `ShareGenerationClient` for Linux AMD64 from the repository root
- verifies the generated binary
- packages it as a deterministic tarball
- generates a SHA-256 checksum
- uploads both files to the matching existing GitHub release

The workflow defaults to `v1.0.0` and can be run for future tags through `workflow_dispatch`.

This PR changes only `.github/workflows/release-linux-amd64.yml`.